### PR TITLE
Fix typo to make goreport "mispell" rating go to 100%

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -62,7 +62,7 @@ const usage = `== Web Development 40 ==
 
 This tool is designed to enable hot reload for any statically hosted web development.
 It injects a websocket script (in a mirrored version of the file) into html pages
-and uses the fsnotify (cross-platform 'inotify' wrapper) packge to detect filechanges.
+and uses the fsnotify (cross-platform 'inotify' wrapper) package to detect filechanges.
 On filechanges, the websocket will trigger a reload of the page. 
 
 The 40 is only to enable rust-repellant properties.


### PR DESCRIPTION

Obligatory "Typo" MR

This will make your "goreportcard" "mispell" score go to 100%

![image](https://github.com/user-attachments/assets/2730e4c7-6c63-4765-9ba9-c747769c0f40)

I'm only fixing a typo from "packge" to "package" here.