### PR TITLE
Tests for file dynamic file updats and cleaned up documentation

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -58,14 +58,15 @@ func formatCommandDescriptions() string {
 	return buf.String()
 }
 
-const usage = `== Web Development 40 == 
+const usage = `== Web Development 41 == 
 
-This tool is designed to enable hot reload for any statically hosted web development.
-It injects a websocket script (in a mirrored version of the file) into html pages
+This tool is designed to enable live reload for statically hosted web development.
+It injects a websocket script in a mirrored version of html pages
 and uses the fsnotify (cross-platform 'inotify' wrapper) package to detect filechanges.
 On filechanges, the websocket will trigger a reload of the page. 
 
-The 40 is only to enable rust-repellant properties.
+The 41 (formerly "40", before I got spooked by potential lawyers) is only 
+to enable rust-repellant properties.
 
 Commands:
 %v`


### PR DESCRIPTION
Changes:
* Updated the usage string to follow the new wd-41 name
* Added tests for dynamic file updates. Turns out: file deletions are currently not supported