### PR TITLE
Added TLS support

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -31,7 +31,8 @@ type command struct {
 	flagset     *flag.FlagSet
 	fileserver  Fileserver
 
-	cacheControl *string
+	cacheControl    *string
+	certificatePath *string
 }
 
 func Command() *command {
@@ -127,6 +128,7 @@ func (c *command) Flagset() *flag.FlagSet {
 	c.wsPath = fs.String("wsPort", "/delta-streamer-ws", "the path which the delta streamer websocket should be hosted on")
 	c.forceReload = fs.Bool("forceReload", false, "set to true if you wish to reload all attached browser pages on any file change")
 	c.cacheControl = fs.String("cacheControl", "no-cache", "set to configure the cache-control header")
+	c.certificatePath = fs.String("certPath", "", "set to some existing cert which should be used for TLS (https)")
 	c.flagset = fs
 	return fs
 }

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -166,4 +166,30 @@ func TestRun(t *testing.T) {
 		got := resp.Header.Get("Cache-Control")
 		testboil.FailTestIfDiff(t, got, want)
 	})
+
+	t.Run("it should serve with tls if cert is specified", func(t *testing.T) {
+		cmd := setup()
+		ctx, ctxCancel := context.WithCancel(context.Background())
+		t.Cleanup(ctxCancel)
+		port := 13337
+		cmd.port = &port
+		cmd.certificatePath = "TODO"
+
+		ready := make(chan struct{})
+		go func() {
+			close(ready)
+			err := cmd.Run(ctx)
+			if err != nil {
+				t.Errorf("Run returned error: %v", err)
+			}
+		}()
+		<-ready
+		time.Sleep(time.Millisecond)
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%v", port))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := resp.Header.Get("Cache-Control")
+		testboil.FailTestIfDiff(t, got, want)
+	})
 }

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -215,7 +215,6 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 			},
 		}
 
-		// Create an HTTP client with the custom transport
 		client := &http.Client{
 			Transport: transport,
 		}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -167,13 +168,34 @@ func TestRun(t *testing.T) {
 		testboil.FailTestIfDiff(t, got, want)
 	})
 
-	t.Run("it should serve with tls if cert is specified", func(t *testing.T) {
+	t.Run("it should serve with tls if cert and key is specified", func(t *testing.T) {
 		cmd := setup()
 		ctx, ctxCancel := context.WithCancel(context.Background())
 		t.Cleanup(ctxCancel)
+		testCert := testboil.CreateTestFile(t, "cert.pem")
+		testCert.Write([]byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`))
+		testKey := testboil.CreateTestFile(t, "key.pem")
+		testKey.Write([]byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`))
 		port := 13337
 		cmd.port = &port
-		cmd.certificatePath = "TODO"
+		certPath := testCert.Name()
+		cmd.tlsCertPath = &certPath
+		keyPath := testKey.Name()
+		cmd.tlsKeyPath = &keyPath
 
 		ready := make(chan struct{})
 		go func() {
@@ -185,11 +207,24 @@ func TestRun(t *testing.T) {
 		}()
 		<-ready
 		time.Sleep(time.Millisecond)
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%v", port))
+
+		// Cert above expired in 2018
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+
+		// Create an HTTP client with the custom transport
+		client := &http.Client{
+			Transport: transport,
+		}
+		resp, err := client.Get(fmt.Sprintf("https://localhost:%v", port))
 		if err != nil {
 			t.Fatal(err)
 		}
-		got := resp.Header.Get("Cache-Control")
-		testboil.FailTestIfDiff(t, got, want)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status code: %v", resp.StatusCode)
+		}
 	})
 }

--- a/internal/wsinject/delta_streamer.ws.go
+++ b/internal/wsinject/delta_streamer.ws.go
@@ -13,7 +13,7 @@ function startWebsocket() {
   }
 
   // Establish a connection with the WebSocket server
-  const socket = new WebSocket('ws://localhost:%v%v');
+  const socket = new WebSocket('ws%v://localhost:%v%v');
 
   // Event handler for when the WebSocket connection is established
   socket.addEventListener('open', function (event) {

--- a/internal/wsinject/wsinject_test.go
+++ b/internal/wsinject/wsinject_test.go
@@ -76,7 +76,7 @@ func Test_Setup(t *testing.T) {
 	}
 	nestedFile := path.Join(nestedDir, "nested.html")
 	os.WriteFile(nestedFile, []byte(mockHtml), 0o777)
-	fs := NewFileServer(8080, "/delta-streamer-ws.js", false)
+	fs := NewFileServer(8080, "/delta-streamer-ws.js", false, false)
 	_, err = fs.Setup(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to setup: %v", err)
@@ -144,7 +144,7 @@ func Test_Start(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create temp dir: %v", err)
 		}
-		return NewFileServer(8080, "/delta-streamer-ws.js", false), testFileSystem{
+		return NewFileServer(8080, "/delta-streamer-ws.js", false, false), testFileSystem{
 			root:      tmpDir,
 			nestedDir: nestedDir,
 		}


### PR DESCRIPTION
Sometimes there might be need to enable https while debugging.

Changes:
* Added new flag `tlsCertPath`
* Added new flag `tlsKeyPath`
* If both `tlsCertPath` and `tlsKeyPath` flags are set, `wd-41` will attempt to start a https server