### PR TITLE
Display full url in messages

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -103,6 +103,8 @@ func (c *command) Run(ctx context.Context) error {
 		ancli.PrintfOK("- Mirror directory: '%v'", c.mirrorPath)
 		if serveTLS {
 			ancli.PrintfOK("- TLS enabled (cert: '%v', key: '%v')", *c.tlsCertPath, *c.tlsKeyPath)
+		} else {
+			ancli.PrintfOK("- TLS disabled")
 		}
 		
 		var err error

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -90,8 +90,21 @@ func (c *command) Run(ctx context.Context) error {
 	go func() {
 		serveTLS := *c.tlsCertPath != "" && *c.tlsKeyPath != ""
 
-		ancli.PrintfOK("now serving directory: '%v' on port: '%v', mirror dir is: '%v', tls: %v, certPath: '%v', keyPath: '%v'",
-			c.masterPath, *c.port, c.mirrorPath, serveTLS, *c.tlsCertPath, *c.tlsKeyPath)
+		hostname := "localhost" // default hostname
+		protocol := "http"
+		if *c.tlsCertPath != "" && *c.tlsKeyPath != "" {
+			protocol = "https"
+		}
+		baseURL := fmt.Sprintf("%s://%s:%d", protocol, hostname, *c.port)
+		
+		ancli.PrintfOK("Server started successfully:")
+		ancli.PrintfOK("- URL: %s", baseURL)
+		ancli.PrintfOK("- Serving directory: '%v'", c.masterPath)
+		ancli.PrintfOK("- Mirror directory: '%v'", c.mirrorPath)
+		if serveTLS {
+			ancli.PrintfOK("- TLS enabled (cert: '%v', key: '%v')", *c.tlsCertPath, *c.tlsKeyPath)
+		}
+		
 		var err error
 		if serveTLS {
 			err = s.ListenAndServeTLS(*c.tlsCertPath, *c.tlsKeyPath)

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -92,7 +92,7 @@ func (c *command) Run(ctx context.Context) error {
 
 		hostname := "localhost" // default hostname
 		protocol := "http"
-		if *c.tlsCertPath != "" && *c.tlsKeyPath != "" {
+		if serveTLS {
 			protocol = "https"
 		}
 		baseURL := fmt.Sprintf("%s://%s:%d", protocol, hostname, *c.port)


### PR DESCRIPTION
When `wd-41` starts, the following is displayed:

```
2024-10-30T21:12:23Z ok: now serving directory: '/root/wd-41' on port: '8080', mirror dir is: '/tmp/wd-41_1660140152', tls: false, certPath: '', keyPath: ''
```

Since my terminal emulator recognizes URL (as I suspect quite a few do), it'd be much more useful for me to have a fuil URL displayed here than I can click on. So this PR replaces the former greeting message with:

```
2024-10-30T21:16:18Z ok: Server started successfully:
2024-10-30T21:16:18Z ok: - URL: http://localhost:8080
2024-10-30T21:16:18Z ok: - Serving directory: '/root/wd-41'
2024-10-30T21:16:18Z ok: - Mirror directory: '/tmp/wd-41_4088355689'
2024-10-30T21:16:18Z ok: - TLS disabled
```

I'm happy to have something else appear as long as `http://localhost:8080` is somewhere to be found in the output.

Thanks for the useful tool at any rate!